### PR TITLE
Feat: Add method that computes aggregate total costs by tag

### DIFF
--- a/e3_django/compute/objects/AlternativeSummary.py
+++ b/e3_django/compute/objects/AlternativeSummary.py
@@ -174,7 +174,7 @@ def ns_elasticity(savings: CostType, total_costs: CostType, delta_q: CostType, t
     return ns_per_pct_q(savings / total_costs, delta_q, total_q_base)
 
 
-def calculate_cash_flow_sum(flows: Iterable[RequiredCashFlow]) -> dict[str, CostType]:
+def calculate_tag_cash_flow_sum(flows: Iterable[RequiredCashFlow]) -> dict[str, CostType]:
     """
     Calculates the sum of cash flows for tags.
 

--- a/e3_django/compute/objects/AlternativeSummary.py
+++ b/e3_django/compute/objects/AlternativeSummary.py
@@ -174,6 +174,16 @@ def ns_elasticity(savings: CostType, total_costs: CostType, delta_q: CostType, t
     return ns_per_pct_q(savings / total_costs, delta_q, total_q_base)
 
 
+def calculate_cash_flow_sum(flows: Iterable[RequiredCashFlow]) -> dict[str, CostType]:
+    """
+    Calculates the sum of cash flows for tags.
+
+    :param flows: The list of flows to calculate aggregate sum for.
+    :return: A dict of the flow tag to its aggregate sum.
+    """
+    return {flow.tag: sum(flow.totTagQ) for flow in flows}
+
+
 def calculate_quant_sum(optionals: Iterable[OptionalCashFlow]) -> dict[str, CostType]:
     """
     Calculates the quantity sums of the given optionals.
@@ -282,6 +292,9 @@ class AlternativeSummary:
 
         # Sum of cash flow discounted, non-invested costs
         self.totalCostsNonInv = sum(flow.totCostDiscNonInv)
+
+        # Sum of cash flows by tag
+        self.totTagFlows = calculate_cash_flow_sum(flow)
 
         # Net benefits between this alternative and the baseline. None if no baseline is provided.
         self.netBenefits = net_benefits(self.totalBenefits, self.totalCosts, baseline.totalBenefits,

--- a/e3_django/compute/serializers/AlternativeSummarySerializer.py
+++ b/e3_django/compute/serializers/AlternativeSummarySerializer.py
@@ -15,6 +15,7 @@ class AlternativeSummarySerializer(Serializer):
     totalCosts = InfinityDecimalField(max_digits=MAX_DIGITS, decimal_places=DECIMAL_PLACES)
     totalCostsInv = InfinityDecimalField(max_digits=MAX_DIGITS, decimal_places=DECIMAL_PLACES)
     totalCostsNonInv = InfinityDecimalField(max_digits=MAX_DIGITS, decimal_places=DECIMAL_PLACES)
+    totTagFlows = InfinityDecimalField(max_digits=MAX_DIGITS, decimal_places=DECIMAL_PLACES)
     netBenefits = InfinityDecimalField(max_digits=MAX_DIGITS, decimal_places=DECIMAL_PLACES, allow_null=True)
     netSavings = InfinityDecimalField(max_digits=MAX_DIGITS, decimal_places=DECIMAL_PLACES, allow_null=True)
     SIR = InfinityDecimalField(max_digits=MAX_DIGITS, decimal_places=DECIMAL_PLACES, allow_null=True)


### PR DESCRIPTION
## Description
This PR adds an attribute `totTagFlows` to AlternativeSummary, which contains the sum of cash flows for tags. This is similar to the way quantSum for AlternativeSummary is currently calculated.

## Motivation and Context
Cost flows by tag were not aggregated in the results anywhere. Using annual cash flows takes a lot more time relative to comparing summed total cost by tag. 

Closes #23 